### PR TITLE
Update path of config in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ see the [Wiki](https://github.com/vaxerski/Hypr/wiki/Building) to see build and 
 # Configuring
 See the [Wiki Page](https://github.com/vaxerski/Hypr/wiki/Configuring-Hypr) for a detailed overview on the config, or refer to the example config in examples/hypr.conf.
 
-You have to use a config, place it in ~/.config/hypr/hypr.conf
+You have to use a config, place it in ~/.config/hypr/hyprland.conf
 
 # Screenshot Gallery
 


### PR DESCRIPTION
Hyperland now auto generates a config in `~/.config/hypr/hyperland.config` when no file is found.
Since the documentation was pointing to `~/.config/hypr/hyper.config` , a new config file was being created by following the guide.

I considered opening an issue, as you indicate in the contribution guidelines. Can drop this and open one, if you want :smile: 